### PR TITLE
Add Jest setup and tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/tests/**/*.test.ts'],
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.jest.json'
+    }
+  }
+};

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "package": "electron-forge package",
     "make": "electron-forge make",
     "publish": "electron-forge publish",
-    "lint": "eslint --ext .ts,.tsx ."
+    "lint": "eslint --ext .ts,.tsx .",
+    "test": "jest"
   },
   "devDependencies": {
     "@electron-forge/cli": "^7.6.0",
@@ -35,7 +36,10 @@
     "style-loader": "^3.3.4",
     "ts-loader": "^9.5.1",
     "ts-node": "^10.9.2",
-    "typescript": "~4.5.4"
+    "typescript": "~4.5.4",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.11"
   },
   "keywords": [],
   "author": {

--- a/tests/utils/files.test.ts
+++ b/tests/utils/files.test.ts
@@ -1,0 +1,21 @@
+import { getFolderNameFromPath, truncatePathFromLeft } from '../../src/app/shared/utils/files';
+
+describe('getFolderNameFromPath', () => {
+  it('returns the last segment of the path', () => {
+    expect(getFolderNameFromPath('folder1\\folder2\\file.txt')).toBe('file.txt');
+  });
+
+  it('handles absolute paths', () => {
+    expect(getFolderNameFromPath('C:\\Users\\User')).toBe('User');
+  });
+});
+
+describe('truncatePathFromLeft', () => {
+  it('removes everything up to and including the specified folder', () => {
+    expect(truncatePathFromLeft('root\\sub\\file.txt', 'root')).toBe('sub\\file.txt');
+  });
+
+  it('returns original path when folder is not found', () => {
+    expect(truncatePathFromLeft('root\\sub\\file.txt', 'none')).toBe('root\\sub\\file.txt');
+  });
+});

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src", "tests"]
+}


### PR DESCRIPTION
## Summary
- add Jest configuration and `npm test` script
- provide tests for utils `getFolderNameFromPath` and `truncatePathFromLeft`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845b6bbbc4c8329b2356f144495f198