### PR TITLE
Fix new file sorting

### DIFF
--- a/src/app/shared/store/files.ts
+++ b/src/app/shared/store/files.ts
@@ -139,7 +139,7 @@ export const getNewFilePaths = async () => {
     }
   }
 
-  newFilePaths.sort();
+  newFilePaths.sort((a, b) => a.newPath.localeCompare(b.newPath));
 
   return newFilePaths;
 };


### PR DESCRIPTION
## Summary
- sort generated file paths by `newPath` so they're in order

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6845b621fff88329a78b912f7a6f0a21