### PR TITLE
Add search filter for tables

### DIFF
--- a/src/app/modules/DirectoryExplorer/components/DirectoryExplorer.tsx
+++ b/src/app/modules/DirectoryExplorer/components/DirectoryExplorer.tsx
@@ -1,5 +1,14 @@
 import { useState } from 'react';
-import { Stack, Button, Breadcrumbs, Typography } from '@mui/material';
+import {
+  Stack,
+  Button,
+  Breadcrumbs,
+  Typography,
+  TextField,
+  InputAdornment,
+  IconButton,
+} from '@mui/material';
+import { Search as SearchIcon, Close as CloseIcon } from '@mui/icons-material';
 import {
   useAppDirectoryStore,
   useUserDirectoryStore,
@@ -40,6 +49,15 @@ export default function DirectoryExplorer() {
 
   const [userTableIsLoding, setUserTableIsLoding] = useState(false);
   const [appTableIsLoding, setAppTableIsLoding] = useState(false);
+  const [userSearch, setUserSearch] = useState('');
+  const [appSearch, setAppSearch] = useState('');
+
+  const filteredUserFilePaths = userFilePaths.filter((file) =>
+    file.path.toLowerCase().includes(userSearch.toLowerCase())
+  );
+  const filteredAppRootDirectories = appRootDirectories.filter((dir) =>
+    dir.path.toLowerCase().includes(appSearch.toLowerCase())
+  );
 
   const renderCell = (folderName: string) => (row: FilePath) =>
     (
@@ -119,46 +137,94 @@ export default function DirectoryExplorer() {
       spacing={2}
       sx={{ height: '100%', paddingTop: 2 }}
     >
-      <Table
-        renderCell={(row) =>
-          renderCell(getFolderNameFromPath(userDirectoryPath))(row)
-        }
-        data={userFilePaths}
-        title="Soubory"
-        title2={renderTitle2(getFolderNameFromPath(userDirectoryPath))}
-        afterTitle={renderRefreshFiles()}
-        onRemove={async (files: FilePath['id'][]) => {
-          setUserTableIsLoding(true);
-          removeUserDirectoryFilePaths(files);
+      <Stack spacing={1}>
+        <TextField
+          value={userSearch}
+          onChange={(e) => setUserSearch(e.target.value)}
+          placeholder="Hledat"
+          size="small"
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <SearchIcon fontSize="small" />
+              </InputAdornment>
+            ),
+            endAdornment: (
+              userSearch && (
+                <InputAdornment position="end">
+                  <IconButton size="small" onClick={() => setUserSearch('')}>
+                    <CloseIcon fontSize="small" />
+                  </IconButton>
+                </InputAdornment>
+              )
+            ),
+          }}
+        />
+        <Table
+          renderCell={(row) =>
+            renderCell(getFolderNameFromPath(userDirectoryPath))(row)
+          }
+          data={filteredUserFilePaths}
+          title="Soubory"
+          title2={renderTitle2(getFolderNameFromPath(userDirectoryPath))}
+          afterTitle={renderRefreshFiles()}
+          onRemove={async (files: FilePath['id'][]) => {
+            setUserTableIsLoding(true);
+            removeUserDirectoryFilePaths(files);
 
-          const newFiles = await getNewFilePaths();
-          setNewFilePaths(newFiles);
+            const newFiles = await getNewFilePaths();
+            setNewFilePaths(newFiles);
 
-          setUserTableIsLoding(false);
-        }}
-        sx={{ maxHeight: '48vh', height: '100%' }}
-        isLoading={userTableIsLoding}
-      />
-      <Table
-        renderCell={(row) =>
-          renderCell(getFolderNameFromPath(appDirectoryPath))(row)
-        }
-        data={appRootDirectories}
-        title="Aplikace"
-        title2={renderTitle2(getFolderNameFromPath(appDirectoryPath))}
-        afterTitle={renderRefreshApps()}
-        onRemove={async (files: FilePath['id'][]) => {
-          setAppTableIsLoding(true);
-          removeAppRootDirectories(files);
+            setUserTableIsLoding(false);
+          }}
+          sx={{ maxHeight: '48vh', height: '100%' }}
+          isLoading={userTableIsLoding}
+        />
+      </Stack>
+      <Stack spacing={1}>
+        <TextField
+          value={appSearch}
+          onChange={(e) => setAppSearch(e.target.value)}
+          placeholder="Hledat"
+          size="small"
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <SearchIcon fontSize="small" />
+              </InputAdornment>
+            ),
+            endAdornment: (
+              appSearch && (
+                <InputAdornment position="end">
+                  <IconButton size="small" onClick={() => setAppSearch('')}>
+                    <CloseIcon fontSize="small" />
+                  </IconButton>
+                </InputAdornment>
+              )
+            ),
+          }}
+        />
+        <Table
+          renderCell={(row) =>
+            renderCell(getFolderNameFromPath(appDirectoryPath))(row)
+          }
+          data={filteredAppRootDirectories}
+          title="Aplikace"
+          title2={renderTitle2(getFolderNameFromPath(appDirectoryPath))}
+          afterTitle={renderRefreshApps()}
+          onRemove={async (files: FilePath['id'][]) => {
+            setAppTableIsLoding(true);
+            removeAppRootDirectories(files);
 
-          const newFiles = await getNewFilePaths();
-          setNewFilePaths(newFiles);
+            const newFiles = await getNewFilePaths();
+            setNewFilePaths(newFiles);
 
-          setAppTableIsLoding(false);
-        }}
-        sx={{ maxHeight: '48vh', height: '100%' }}
-        isLoading={appTableIsLoding}
-      />
+            setAppTableIsLoding(false);
+          }}
+          sx={{ maxHeight: '48vh', height: '100%' }}
+          isLoading={appTableIsLoding}
+        />
+      </Stack>
       <Stack
         direction="row"
         justifyContent="space-between"

--- a/src/app/modules/DirectoryExplorer/components/DirectoryExplorer.tsx
+++ b/src/app/modules/DirectoryExplorer/components/DirectoryExplorer.tsx
@@ -1,14 +1,5 @@
 import { useState } from 'react';
-import {
-  Stack,
-  Button,
-  Breadcrumbs,
-  Typography,
-  TextField,
-  InputAdornment,
-  IconButton,
-} from '@mui/material';
-import { Search as SearchIcon, Close as CloseIcon } from '@mui/icons-material';
+import { Stack, Button, Breadcrumbs, Typography } from '@mui/material';
 import {
   useAppDirectoryStore,
   useUserDirectoryStore,
@@ -18,7 +9,7 @@ import {
 } from '../../../shared/store/files';
 import { useWindowStore } from '../../../shared/store/window';
 import { FilePath } from '../../../shared/types/files';
-import Table from '../../../shared/ui/Table';
+import SearchableTable from '../../../shared/ui/SearchableTable';
 import { getFolderNameFromPath } from '../../../shared/utils/files';
 import { truncatePathFromLeft } from '../../../shared/utils/files';
 import RefreshButton from '../../../shared/ui/RefreshButton';
@@ -49,15 +40,6 @@ export default function DirectoryExplorer() {
 
   const [userTableIsLoding, setUserTableIsLoding] = useState(false);
   const [appTableIsLoding, setAppTableIsLoding] = useState(false);
-  const [userSearch, setUserSearch] = useState('');
-  const [appSearch, setAppSearch] = useState('');
-
-  const filteredUserFilePaths = userFilePaths.filter((file) =>
-    file.path.toLowerCase().includes(userSearch.toLowerCase())
-  );
-  const filteredAppRootDirectories = appRootDirectories.filter((dir) =>
-    dir.path.toLowerCase().includes(appSearch.toLowerCase())
-  );
 
   const renderCell = (folderName: string) => (row: FilePath) =>
     (
@@ -137,94 +119,46 @@ export default function DirectoryExplorer() {
       spacing={2}
       sx={{ height: '100%', paddingTop: 2 }}
     >
-      <Stack spacing={1}>
-        <TextField
-          value={userSearch}
-          onChange={(e) => setUserSearch(e.target.value)}
-          placeholder="Hledat"
-          size="small"
-          InputProps={{
-            startAdornment: (
-              <InputAdornment position="start">
-                <SearchIcon fontSize="small" />
-              </InputAdornment>
-            ),
-            endAdornment: (
-              userSearch && (
-                <InputAdornment position="end">
-                  <IconButton size="small" onClick={() => setUserSearch('')}>
-                    <CloseIcon fontSize="small" />
-                  </IconButton>
-                </InputAdornment>
-              )
-            ),
-          }}
-        />
-        <Table
-          renderCell={(row) =>
-            renderCell(getFolderNameFromPath(userDirectoryPath))(row)
-          }
-          data={filteredUserFilePaths}
-          title="Soubory"
-          title2={renderTitle2(getFolderNameFromPath(userDirectoryPath))}
-          afterTitle={renderRefreshFiles()}
-          onRemove={async (files: FilePath['id'][]) => {
-            setUserTableIsLoding(true);
-            removeUserDirectoryFilePaths(files);
+      <SearchableTable
+        renderCell={(row) =>
+          renderCell(getFolderNameFromPath(userDirectoryPath))(row)
+        }
+        data={userFilePaths}
+        title="Soubory"
+        title2={renderTitle2(getFolderNameFromPath(userDirectoryPath))}
+        afterTitle={renderRefreshFiles()}
+        onRemove={async (files: FilePath['id'][]) => {
+          setUserTableIsLoding(true);
+          removeUserDirectoryFilePaths(files);
 
-            const newFiles = await getNewFilePaths();
-            setNewFilePaths(newFiles);
+          const newFiles = await getNewFilePaths();
+          setNewFilePaths(newFiles);
 
-            setUserTableIsLoding(false);
-          }}
-          sx={{ maxHeight: '48vh', height: '100%' }}
-          isLoading={userTableIsLoding}
-        />
-      </Stack>
-      <Stack spacing={1}>
-        <TextField
-          value={appSearch}
-          onChange={(e) => setAppSearch(e.target.value)}
-          placeholder="Hledat"
-          size="small"
-          InputProps={{
-            startAdornment: (
-              <InputAdornment position="start">
-                <SearchIcon fontSize="small" />
-              </InputAdornment>
-            ),
-            endAdornment: (
-              appSearch && (
-                <InputAdornment position="end">
-                  <IconButton size="small" onClick={() => setAppSearch('')}>
-                    <CloseIcon fontSize="small" />
-                  </IconButton>
-                </InputAdornment>
-              )
-            ),
-          }}
-        />
-        <Table
-          renderCell={(row) =>
-            renderCell(getFolderNameFromPath(appDirectoryPath))(row)
-          }
-          data={filteredAppRootDirectories}
-          title="Aplikace"
-          title2={renderTitle2(getFolderNameFromPath(appDirectoryPath))}
-          afterTitle={renderRefreshApps()}
-          onRemove={async (files: FilePath['id'][]) => {
-            setAppTableIsLoding(true);
-            removeAppRootDirectories(files);
+          setUserTableIsLoding(false);
+        }}
+        sx={{ maxHeight: '48vh', height: '100%' }}
+        isLoading={userTableIsLoding}
+      />
+      <SearchableTable
+        renderCell={(row) =>
+          renderCell(getFolderNameFromPath(appDirectoryPath))(row)
+        }
+        data={appRootDirectories}
+        title="Aplikace"
+        title2={renderTitle2(getFolderNameFromPath(appDirectoryPath))}
+        afterTitle={renderRefreshApps()}
+        onRemove={async (files: FilePath['id'][]) => {
+          setAppTableIsLoding(true);
+          removeAppRootDirectories(files);
 
-            const newFiles = await getNewFilePaths();
-            setNewFilePaths(newFiles);
+          const newFiles = await getNewFilePaths();
+          setNewFilePaths(newFiles);
 
-            setAppTableIsLoding(false);
-          }}
-          sx={{ maxHeight: '48vh', height: '100%' }}
-          isLoading={appTableIsLoding}
-        />
-      </Stack>
+          setAppTableIsLoding(false);
+        }}
+        sx={{ maxHeight: '48vh', height: '100%' }}
+        isLoading={appTableIsLoding}
+      />
       <Stack
         direction="row"
         justifyContent="space-between"

--- a/src/app/shared/ui/SearchField.tsx
+++ b/src/app/shared/ui/SearchField.tsx
@@ -1,0 +1,34 @@
+import { TextField, InputAdornment, IconButton } from '@mui/material';
+import { Search as SearchIcon, Close as CloseIcon } from '@mui/icons-material';
+
+interface Props {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+}
+
+export default function SearchField({ value, onChange, placeholder = 'Hledat' }: Props) {
+  return (
+    <TextField
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder={placeholder}
+      size="small"
+      InputProps={{
+        startAdornment: (
+          <InputAdornment position="start">
+            <SearchIcon fontSize="small" />
+          </InputAdornment>
+        ),
+        endAdornment:
+          value && (
+            <InputAdornment position="end">
+              <IconButton size="small" onClick={() => onChange('')}>
+                <CloseIcon fontSize="small" />
+              </IconButton>
+            </InputAdornment>
+          ),
+      }}
+    />
+  );
+}

--- a/src/app/shared/ui/SearchableTable.tsx
+++ b/src/app/shared/ui/SearchableTable.tsx
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+import { Stack, SxProps } from '@mui/material';
+import Table from './Table';
+import SearchField from './SearchField';
+
+interface TableData {
+  id: string;
+  path: string;
+}
+
+interface Props<T extends TableData> {
+  title: string;
+  title2?: React.ReactNode;
+  afterTitle?: React.ReactNode;
+  editable?: boolean;
+  data: T[];
+  onRemove: (ids: string[]) => void;
+  renderCell: (row: T) => React.ReactNode;
+  sx?: SxProps;
+  isLoading?: boolean;
+}
+
+export default function SearchableTable<T extends TableData>({
+  data,
+  ...props
+}: Props<T>) {
+  const [search, setSearch] = useState('');
+
+  const filteredData = data.filter((row) =>
+    row.path.toLowerCase().includes(search.toLowerCase())
+  );
+
+  return (
+    <Stack spacing={1}>
+      <SearchField value={search} onChange={setSearch} />
+      <Table<T> {...props} data={filteredData} />
+    </Stack>
+  );
+}


### PR DESCRIPTION
## Summary
- add search fields to DirectoryExplorer tables so users can quickly filter folders and files

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: eslint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_6845bb0868588329bf8031d98c652d65